### PR TITLE
Podman/Docker testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
-# Git ignore
 
+README.md
 download_logs.txt
 *.mp3
 *.mp4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+
+FROM alpine:latest
+
+WORKDIR /app
+
+COPY . .
+
+RUN apk update
+RUN apk add --no-cache bash
+RUN apk add --no-cache ffmpeg
+RUN apk add --no-cache yt-dlp
+RUN mkdir -p /media
+
+CMD ["./docker_script.sh"]
+
+
+

--- a/README.md
+++ b/README.md
@@ -7,13 +7,28 @@ Disclaimer: Make sure to have both `ffmpeg` and `yt-dlp` installed for this to w
 
 Usage instructions: 
 
-``` 
+```
 git clone https://github.com/Sibidine/Video-Clipping-tool.git
 cd Video-Clipping-tool
 chmod +x dependency_check.sh
 ./dependency_check.sh
 chmod +x clip.sh
 ./clip.sh
+```
+
+Podman/Docker testing
+
+To try this out even if your distribution does not have the latest version of yt-dlp and ffmpeg.
+You may replace podman with docker.
+Clone the repo, cd into it and then build the image
+```
+podman build --no-cache --rm -t video-clipping-tool-image .
+podman run -it -v $(pwd):/media video-clipping-tool-image
+```
+
+To remove the image
+```
+podman rmi --force video-clipping-tool-image
 ```
 
 Todo- Add a master script that invokes both the current scripts, and correct the readme to give instructions to run the master script instead.

--- a/docker_script.sh
+++ b/docker_script.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+
+./dependency_check.sh
+./clip.sh
+
+pwd
+ls -la
+
+cp *.mp4 *.mp3  /media
+cp download_logs.txt  /media


### PR DESCRIPTION
Certain distrubutions have deprecated versions of yt-dlp. Running the application in a podman/docker container is a sensible way of solving this dependency problem.

Alpine linux image has been chosen as its extremely lightweight.

Since, the command for running the application is very long, it can be aliased to a shorter name