### PR TITLE
download videos in mp4 instead of webm

### DIFF
--- a/clip.sh
+++ b/clip.sh
@@ -36,7 +36,7 @@ then
 	elif [[ file_type -eq 2 ]]
 	then
 		#  VIDEO
-		yt-dlp "$link" > download_logs.txt
+		yt-dlp "$link" -S res,ext:mp4:m4a --recode mp4 > download_logs.txt
 	fi
 
 # PORTION OF THE FULL VIDEO


### PR DESCRIPTION
Full video download uses `.mp4` instead of `.webm` now. Credit to [this reddit post](https://old.reddit.com/r/youtubedl/comments/lnrtid/ytdlp_release_20210219/go3v7ye/?context=10000).